### PR TITLE
Add back button & dismiss record finish automatically

### DIFF
--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -33,7 +33,7 @@
       </ion-fab-button>
     </ion-fab-list>
     <ion-fab-list  side="top">
-      <ion-fab-button  color="light" (click)="onClickRecordButton()">
+      <ion-fab-button color="light" [routerLink]="['/add-record']">
         <ion-icon name="pencil-outline"></ion-icon>
       </ion-fab-button>
     </ion-fab-list>


### PR DESCRIPTION
Closes #95, #96

- Make add record a regular routed page instead of a modal to show the
default back button of Ionic toolbar

- Upon click or after 0.5 sec, the record finish popover will be
dismissed, then the user will be redirected back to the last page
visited