### PR TITLE
Fix that photos took in previous build cannot be displayed in web and

### DIFF
--- a/src/app/core/classes/daily-record.ts
+++ b/src/app/core/classes/daily-record.ts
@@ -50,4 +50,21 @@ export class DailyRecord {
         }
     }
 
+    getLatestPhotoByteString(): string {
+        function flatten<T>(arr: T[][]): Array<T> {
+            return arr.reduce((flat, next) => flat.concat(next), []);
+        }
+
+        const nestedPhotos = this.records.map(record => record.photos);
+        const photos = flatten(nestedPhotos);
+        const sortedPhotos = photos
+            .filter(photo => photo !== undefined)
+            .sort((a, b) => +b.timestamp - +a.timestamp);
+        if (sortedPhotos[0]) {
+            return sortedPhotos[0].byteString;
+        } else {
+            return '';
+        }
+    }
+
 }

--- a/src/app/core/classes/overview-daily-card.ts
+++ b/src/app/core/classes/overview-daily-card.ts
@@ -12,6 +12,7 @@ export class OverviewDailyCard implements DailyCard {
     bt: string;
     imgSrc: string;
     imgHeight: number;
+    imgByteString?: string;
     presentedSymptoms?: string[];
     locations?: LocationStamp[];
 
@@ -33,6 +34,7 @@ export class OverviewDailyCard implements DailyCard {
         }
         this.bt = `${dailyRecord.getHighestBt()}`;
         this.imgSrc = dailyRecord.getLatestPhotoPath();
+        this.imgByteString = dailyRecord.getLatestPhotoByteString();
         this.locations = dailyRecord.records
             .map(record => record.locationStamp)
             .filter(locationStamp => locationStamp !== undefined);

--- a/src/app/core/pages/img-popover/img-popover.page.html
+++ b/src/app/core/pages/img-popover/img-popover.page.html
@@ -8,7 +8,7 @@
     <ion-col>
 
       <div style="display: flex;flex-direction: column;height: 40vw;">
-        <img [src]="photo.webviewPath | safeUrl" style="height: 39vw;" />
+        <img [src]="'data:image/jpeg;base64,' + photo.byteString" style="height: 39vw;" />
       </div>
 
     </ion-col>

--- a/src/app/core/pages/img-viewer/img-viewer.page.html
+++ b/src/app/core/pages/img-viewer/img-viewer.page.html
@@ -19,11 +19,11 @@
   <div style="border-width:0.5px;border-bottom-style:groove;border-color:#555555;margin-right: 25px;margin-left: 25px;">
   </div>
   <div style="display: flex;flex-direction: column;height: 40vw;">
-    <ion-img [src]="photo.webviewPath" style="width: 100%;"></ion-img>
+    <ion-img [src]="'data:image/jpeg;base64,' + photo.byteString" style="width: 100%;"></ion-img>
   </div>
   <!-- <ion-label>Label</ion-label>
   <ion-label>{{ firstName   }}</ion-label>
   <ion-label>{{ lastName   }}</ion-label>
   <ion-label>{{ photo.locationStamp.latitude   }}</ion-label>
-  <ion-label>{{ photo.webviewPath  }}</ion-label> -->
+  <ion-label>{{ 'data:image/jpeg;base64,' + photo.byteString  }}</ion-label> -->
 </ion-content>

--- a/src/app/daily/daily-detail/daily-detail-photos/daily-detail-photos.component.html
+++ b/src/app/daily/daily-detail/daily-detail-photos/daily-detail-photos.component.html
@@ -3,10 +3,10 @@
     <div style="display: flex;flex-direction: row;flex-wrap: wrap;">
       <ion-thumbnail *ngFor="let photo of photos$ | async">
         <!-- <div (click)="openImageModal(photo)">
-          <ion-img [src]="photo.webviewPath"></ion-img>
+          <ion-img [src]="'data:image/jpeg;base64,' + photo.byteString"></ion-img>
         </div> -->
         <div  (click)="showImageViewer(photo)">
-          <ion-img [src]="photo.webviewPath"></ion-img>
+          <ion-img [src]="'data:image/jpeg;base64,' + photo.byteString"></ion-img>
         </div>
       </ion-thumbnail>
     </div>

--- a/src/app/daily/daily-overview/daily-overview.component.html
+++ b/src/app/daily/daily-overview/daily-overview.component.html
@@ -33,8 +33,8 @@
           </ion-col>
           <ion-col size="7">
             <ion-thumbnail>
-              <ion-img *ngIf="!item.imgSrc" src="/assets/imgA.png" alt="No picture"></ion-img>
-              <ion-img *ngIf="item.imgSrc" [src]="item.imgSrc" alt="No picture"></ion-img>
+              <ion-img *ngIf="!item.imgByteString" src="/assets/imgA.png" alt="No picture"></ion-img>
+              <ion-img *ngIf="item.imgByteString" [src]="'data:image/jpeg;base64,' + item.imgByteString" alt="No picture"></ion-img>
             </ion-thumbnail>
           </ion-col>
         </ion-row>


### PR DESCRIPTION
ios

- File URI and webview changes on every build on web or ios, so the
saved path should not be used

- Display the photos using saved byteString instead